### PR TITLE
GDB path fix

### DIFF
--- a/docs/labs/2026 Labs/Week 7 Lab.md
+++ b/docs/labs/2026 Labs/Week 7 Lab.md
@@ -355,7 +355,7 @@ Now you need to open a second terminal (... and `vagrant ssh` in your guest)
 and do the following:
 ```
 cd os161/root/
-os161-gdb kernel
+mips-harvard-os161-gdb kernel
 ```
 
 Now in the GDB prompt type the following:


### PR DESCRIPTION
In week 7 lab, Vagrant method had an alias for "mips-harvard-os161-gdb" ("os161-gdb"). This wasn't consistent with the newer method. I changed the lab sheet for unified guide (works both on Vagrant and new execution method).